### PR TITLE
Allow schemas to be used in VS Code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,9 @@
 {
-  "editor.tabSize": 4
+  "editor.tabSize": 4,
+  "json.schemas": [
+    {
+      "fileMatch": ["index/*.json"],
+      "url": "./resources/org_index_schema.json"
+    }
+  ]
 }

--- a/resources/app_index_schema.json
+++ b/resources/app_index_schema.json
@@ -1,18 +1,191 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://nordicsemi.no/app_index/schemas/app_index.json",
     "type": "object",
     "properties": {
         "orgs": {
             "type": "object",
             "additionalProperties": {
-                "$ref": "http://nordicsemi.no/app_index/schemas/org.json"
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "type": {
+                        "type": "string",
+                        "enum": [
+                            "User",
+                            "Organization"
+                        ]
+                    },
+                    "isPartner": {
+                        "type": "boolean"
+                    },
+                    "location": {
+                        "type": "string"
+                    },
+                    "avatar": {
+                        "type": "string",
+                        "format": "uri"
+                    },
+                    "urls": {
+                        "type": "object",
+                        "properties": {
+                            "support": {
+                                "type": "string",
+                                "format": "uri"
+                            },
+                            "email": {
+                                "type": "string",
+                                "format": "uri"
+                            },
+                            "blog": {
+                                "type": "string",
+                                "format": "uri"
+                            },
+                            "twitter": {
+                                "type": "string",
+                                "format": "uri"
+                            }
+                        },
+                        "required": [
+                            "support"
+                        ],
+                        "additionalProperties": false
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "description",
+                    "type",
+                    "isPartner",
+                    "urls"
+                ],
+                "additionalProperties": false
             }
         },
         "apps": {
             "type": "array",
             "items": {
-                "$ref": "http://nordicsemi.no/app_index/schemas/app.json"
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string"
+                    },
+                    "license": {
+                        "type": "string"
+                    },
+                    "repo": {
+                        "type": "string"
+                    },
+                    "isTemplate": {
+                        "type": "boolean"
+                    },
+                    "owner": {
+                        "type": "string",
+                        "description": "The ID of the owner organization."
+                    },
+                    "manifest": {
+                        "type": "string"
+                    },
+                    "kind": {
+                        "description": "The type of the app repo.",
+                        "oneOf": [
+                            {
+                                "const": "template",
+                                "description": "A starting point for new apps"
+                            },
+                            {
+                                "const": "sample",
+                                "description": "A demonstration of a concept."
+                            },
+                            {
+                                "const": "project",
+                                "description": "A fully-fledged project users can run on their devices."
+                            }
+                        ]
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "enum": [
+                                "bluetooth",
+                                "zigbee",
+                                "lte",
+                                "dfu",
+                                "thread",
+                                "matter",
+                                "bt-mesh"
+                            ]
+                        }
+                    },
+                    "releases": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "tag": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "date": {
+                                    "type": "string",
+                                    "format": "date"
+                                }
+                            },
+                            "required": [
+                                "tag",
+                                "name",
+                                "date"
+                            ],
+                            "additionalProperties": false
+                        },
+                        "minItems": 1
+                    },
+                    "watchers": {
+                        "type": "integer"
+                    },
+                    "forks": {
+                        "type": "integer"
+                    },
+                    "defaultBranch": {
+                        "type": "string"
+                    },
+                    "lastUpdate": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "description",
+                    "isTemplate",
+                    "owner",
+                    "kind",
+                    "tags",
+                    "releases",
+                    "watchers",
+                    "forks",
+                    "defaultBranch",
+                    "lastUpdate",
+                    "repo"
+                ],
+                "additionalProperties": false
             }
         }
     },
@@ -20,197 +193,5 @@
         "orgs",
         "apps"
     ],
-    "additionalProperties": false,
-    "definitions": {
-        "http://nordicsemi.no/app_index/schemas/app_kind.json": {
-            "$id": "http://nordicsemi.no/app_index/schemas/app_kind.json",
-            "oneOf": [
-                {
-                    "const": "template",
-                    "description": "A starting point for new apps"
-                },
-                {
-                    "const": "sample",
-                    "description": "A demonstration of a concept."
-                },
-                {
-                    "const": "project",
-                    "description": "A fully-fledged project users can run on their devices."
-                }
-            ]
-        },
-        "http://nordicsemi.no/app_index/schemas/app_tag.json": {
-            "$id": "http://nordicsemi.no/app_index/schemas/app_tag.json",
-            "enum": [
-                "bluetooth",
-                "zigbee",
-                "lte",
-                "dfu",
-                "thread",
-                "matter",
-                "bt-mesh"
-            ]
-        },
-        "http://nordicsemi.no/app_index/schemas/org.json": {
-            "$id": "http://nordicsemi.no/app_index/schemas/org.json",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "organization",
-                        "user"
-                    ]
-                },
-                "isPartner": {
-                    "type": "boolean"
-                },
-                "location": {
-                    "type": "string"
-                },
-                "avatar": {
-                    "type": "string",
-                    "format": "uri"
-                },
-                "urls": {
-                    "type": "object",
-                    "properties": {
-                        "support": {
-                            "type": "string",
-                            "format": "uri"
-                        },
-                        "email": {
-                            "type": "string",
-                            "format": "uri"
-                        },
-                        "blog": {
-                            "type": "string",
-                            "format": "uri"
-                        },
-                        "twitter": {
-                            "type": "string",
-                            "format": "uri"
-                        }
-                    },
-                    "required": [
-                        "support"
-                    ],
-                    "additionalProperties": false
-                }
-            },
-            "required": [
-                "id",
-                "name",
-                "description",
-                "type",
-                "isPartner",
-                "urls"
-            ],
-            "additionalProperties": false
-        },
-        "http://nordicsemi.no/app_index/schemas/app.json": {
-            "$id": "http://nordicsemi.no/app_index/schemas/app.json",
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "description": {
-                    "type": "string"
-                },
-                "license": {
-                    "type": "string"
-                },
-                "repo": {
-                    "type": "string"
-                },
-                "isTemplate": {
-                    "type": "boolean"
-                },
-                "owner": {
-                    "type": "string",
-                    "description": "The ID of the owner organization."
-                },
-                "manifest": {
-                    "type": "string"
-                },
-                "kind": {
-                    "$ref": "http://nordicsemi.no/app_index/schemas/app_kind.json"
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "http://nordicsemi.no/app_index/schemas/app_tag.json"
-                    }
-                },
-                "releases": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "tag": {
-                                "type": "string"
-                            },
-                            "name": {
-                                "type": "string"
-                            },
-                            "date": {
-                                "type": "string",
-                                "format": "date"
-                            }
-                        },
-                        "required": [
-                            "tag",
-                            "name",
-                            "date"
-                        ],
-                        "additionalProperties": false
-                    },
-                    "minItems": 1
-                },
-                "watchers": {
-                    "type": "integer"
-                },
-                "forks": {
-                    "type": "integer"
-                },
-                "defaultBranch": {
-                    "type": "string"
-                },
-                "lastUpdate": {
-                    "type": "string",
-                    "format": "date-time"
-                }
-            },
-            "required": [
-                "id",
-                "name",
-                "description",
-                "license",
-                "isTemplate",
-                "owner",
-                "kind",
-                "tags",
-                "releases",
-                "watchers",
-                "forks",
-                "defaultBranch",
-                "lastUpdate",
-                "repo"
-            ],
-            "additionalProperties": false
-        }
-    }
+    "additionalProperties": false
 }

--- a/resources/org_index_schema.json
+++ b/resources/org_index_schema.json
@@ -1,6 +1,5 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://nordicsemi.no/app_index/schemas/org_index.json",
     "type": "object",
     "properties": {
         "name": {
@@ -14,7 +13,60 @@
         "apps": {
             "type": "array",
             "items": {
-                "$ref": "http://nordicsemi.no/app_index/schemas/app_metadata.json"
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the application."
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Text describing the application. Inferred from the repo if missing."
+                    },
+                    "manifest": {
+                        "type": "string",
+                        "default": "west.yml",
+                        "description": "Alternative filename for the west manifest. Defaults to west.yml."
+                    },
+                    "kind": {
+                        "description": "The type of the app repo.",
+                        "oneOf": [
+                            {
+                                "const": "template",
+                                "description": "A starting point for new apps"
+                            },
+                            {
+                                "const": "sample",
+                                "description": "A demonstration of a concept."
+                            },
+                            {
+                                "const": "project",
+                                "description": "A fully-fledged project users can run on their devices."
+                            }
+                        ]
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "enum": [
+                                "bluetooth",
+                                "zigbee",
+                                "lte",
+                                "dfu",
+                                "thread",
+                                "matter",
+                                "bt-mesh"
+                            ]
+                        },
+                        "description": "An array of tags describing the application."
+                    }
+                },
+                "additionalProperties": false,
+                "required": [
+                    "name",
+                    "kind",
+                    "tags"
+                ]
             },
             "description": "A list of applications contributed by the organization."
         }
@@ -24,72 +76,5 @@
         "description",
         "apps"
     ],
-    "additionalProperties": false,
-    "definitions": {
-        "http://nordicsemi.no/app_index/schemas/app_kind.json": {
-            "$id": "http://nordicsemi.no/app_index/schemas/app_kind.json",
-            "oneOf": [
-                {
-                    "const": "template",
-                    "description": "A starting point for new apps"
-                },
-                {
-                    "const": "sample",
-                    "description": "A demonstration of a concept."
-                },
-                {
-                    "const": "project",
-                    "description": "A fully-fledged project users can run on their devices."
-                }
-            ]
-        },
-        "http://nordicsemi.no/app_index/schemas/app_tag.json": {
-            "$id": "http://nordicsemi.no/app_index/schemas/app_tag.json",
-            "enum": [
-                "bluetooth",
-                "zigbee",
-                "lte",
-                "dfu",
-                "thread",
-                "matter",
-                "bt-mesh"
-            ]
-        },
-        "http://nordicsemi.no/app_index/schemas/app_metadata.json": {
-            "$id": "http://nordicsemi.no/app_index/schemas/app_metadata.json",
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "The name of the application."
-                },
-                "description": {
-                    "type": "string",
-                    "description": "Text describing the application. Inferred from the repo if missing."
-                },
-                "manifest": {
-                    "type": "string",
-                    "default": "west.yml",
-                    "description": "T"
-                },
-                "kind": {
-                    "$ref": "http://nordicsemi.no/app_index/schemas/app_kind.json",
-                    "description": "The type of application repo."
-                },
-                "tags": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "http://nordicsemi.no/app_index/schemas/app_tag.json"
-                    },
-                    "description": "An array of tags describing the application."
-                }
-            },
-            "additionalProperties": false,
-            "required": [
-                "name",
-                "kind",
-                "tags"
-            ]
-        }
-    }
+    "additionalProperties": false
 }

--- a/scripts/generate-schemas.ts
+++ b/scripts/generate-schemas.ts
@@ -10,8 +10,6 @@ import type { JSONSchema } from 'json-schema-to-ts';
 
 import * as Schemas from '../site/src/schema';
 
-const { SchemaIds } = Schemas;
-
 async function writeSchema(name: string, schema: JSONSchema) {
     const schemaPath = path.join(__dirname, '..', 'resources', `${name}.json`);
     const schemaJSON = JSON.stringify(schema, undefined, 4);
@@ -24,21 +22,10 @@ async function writeSchemas(): Promise<void[]> {
         writeSchema('org_index_schema', {
             $schema: 'http://json-schema.org/draft-07/schema#',
             ...Schemas.orgIndexSchema,
-            definitions: {
-                [SchemaIds.AppKind]: Schemas.appKindSchema,
-                [SchemaIds.AppTag]: Schemas.appTagSchema,
-                [SchemaIds.AppMetadata]: Schemas.appMetadataSchema,
-            },
         }),
         writeSchema('app_index_schema', {
             $schema: 'http://json-schema.org/draft-07/schema#',
             ...Schemas.appIndexSchema,
-            definitions: {
-                [SchemaIds.AppKind]: Schemas.appKindSchema,
-                [SchemaIds.AppTag]: Schemas.appTagSchema,
-                [SchemaIds.Organization]: Schemas.orgSchema,
-                [SchemaIds.Application]: Schemas.appSchema,
-            },
         }),
     ]);
 }


### PR DESCRIPTION
The reference mechanism used for the schemas did not actually match any real online resources, which throws off the JSON language support in VS Code. As each object isn't actually used more than once in each schema, we might as well inline them all and simplify both the resulting schemas and the generation script.

Additionally sets the schema for index files in the vscode workspace settings, so that they're automatically validated when editing.