### PR TITLE
Bump Next.js to get rid of zod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "fuse.js": "^6.6.2",
                 "json-schema-to-ts": "^2.9.2",
                 "lodash": "^4.17.21",
-                "next": "^13.4.19",
+                "next": "^13.5.4",
                 "node-fetch": "^3.3.2",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0",
@@ -508,14 +508,14 @@
             }
         },
         "node_modules/@next/env": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
-            "integrity": "sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ=="
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.4.tgz",
+            "integrity": "sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ=="
         },
         "node_modules/@next/swc-darwin-arm64": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz",
-            "integrity": "sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.4.tgz",
+            "integrity": "sha512-Df8SHuXgF1p+aonBMcDPEsaahNo2TCwuie7VXED4FVyECvdXfRT9unapm54NssV9tF3OQFKBFOdlje4T43VO0w==",
             "cpu": [
                 "arm64"
             ],
@@ -528,9 +528,9 @@
             }
         },
         "node_modules/@next/swc-darwin-x64": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.19.tgz",
-            "integrity": "sha512-jyzO6wwYhx6F+7gD8ddZfuqO4TtpJdw3wyOduR4fxTUCm3aLw7YmHGYNjS0xRSYGAkLpBkH1E0RcelyId6lNsw==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.4.tgz",
+            "integrity": "sha512-siPuUwO45PnNRMeZnSa8n/Lye5ZX93IJom9wQRB5DEOdFrw0JjOMu1GINB8jAEdwa7Vdyn1oJ2xGNaQpdQQ9Pw==",
             "cpu": [
                 "x64"
             ],
@@ -543,9 +543,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-gnu": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.19.tgz",
-            "integrity": "sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.4.tgz",
+            "integrity": "sha512-l/k/fvRP/zmB2jkFMfefmFkyZbDkYW0mRM/LB+tH5u9pB98WsHXC0WvDHlGCYp3CH/jlkJPL7gN8nkTQVrQ/2w==",
             "cpu": [
                 "arm64"
             ],
@@ -558,9 +558,9 @@
             }
         },
         "node_modules/@next/swc-linux-arm64-musl": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.19.tgz",
-            "integrity": "sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.4.tgz",
+            "integrity": "sha512-YYGb7SlLkI+XqfQa8VPErljb7k9nUnhhRrVaOdfJNCaQnHBcvbT7cx/UjDQLdleJcfyg1Hkn5YSSIeVfjgmkTg==",
             "cpu": [
                 "arm64"
             ],
@@ -573,9 +573,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-gnu": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.19.tgz",
-            "integrity": "sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.4.tgz",
+            "integrity": "sha512-uE61vyUSClnCH18YHjA8tE1prr/PBFlBFhxBZis4XBRJoR+txAky5d7gGNUIbQ8sZZ7LVkSVgm/5Fc7mwXmRAg==",
             "cpu": [
                 "x64"
             ],
@@ -588,9 +588,9 @@
             }
         },
         "node_modules/@next/swc-linux-x64-musl": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.19.tgz",
-            "integrity": "sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.4.tgz",
+            "integrity": "sha512-qVEKFYML/GvJSy9CfYqAdUexA6M5AklYcQCW+8JECmkQHGoPxCf04iMh7CPR7wkHyWWK+XLt4Ja7hhsPJtSnhg==",
             "cpu": [
                 "x64"
             ],
@@ -603,9 +603,9 @@
             }
         },
         "node_modules/@next/swc-win32-arm64-msvc": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.19.tgz",
-            "integrity": "sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.4.tgz",
+            "integrity": "sha512-mDSQfqxAlfpeZOLPxLymZkX0hYF3juN57W6vFHTvwKlnHfmh12Pt7hPIRLYIShk8uYRsKPtMTth/EzpwRI+u8w==",
             "cpu": [
                 "arm64"
             ],
@@ -618,9 +618,9 @@
             }
         },
         "node_modules/@next/swc-win32-ia32-msvc": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.19.tgz",
-            "integrity": "sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.4.tgz",
+            "integrity": "sha512-aoqAT2XIekIWoriwzOmGFAvTtVY5O7JjV21giozBTP5c6uZhpvTWRbmHXbmsjZqY4HnEZQRXWkSAppsIBweKqw==",
             "cpu": [
                 "ia32"
             ],
@@ -633,9 +633,9 @@
             }
         },
         "node_modules/@next/swc-win32-x64-msvc": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz",
-            "integrity": "sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.4.tgz",
+            "integrity": "sha512-cyRvlAxwlddlqeB9xtPSfNSCRy8BOa4wtMo0IuI9P7Y0XT2qpDrpFKRyZ7kUngZis59mPVla5k8X1oOJ8RxDYg==",
             "cpu": [
                 "x64"
             ],
@@ -851,9 +851,9 @@
             }
         },
         "node_modules/@swc/helpers": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
-            "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+            "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
             "dependencies": {
                 "tslib": "^2.4.0"
             }
@@ -1681,35 +1681,34 @@
             }
         },
         "node_modules/next": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/next/-/next-13.4.19.tgz",
-            "integrity": "sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/next/-/next-13.5.4.tgz",
+            "integrity": "sha512-+93un5S779gho8y9ASQhb/bTkQF17FNQOtXLKAj3lsNgltEcF0C5PMLLncDmH+8X1EnJH1kbqAERa29nRXqhjA==",
             "dependencies": {
-                "@next/env": "13.4.19",
-                "@swc/helpers": "0.5.1",
+                "@next/env": "13.5.4",
+                "@swc/helpers": "0.5.2",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001406",
-                "postcss": "8.4.14",
+                "postcss": "8.4.31",
                 "styled-jsx": "5.1.1",
-                "watchpack": "2.4.0",
-                "zod": "3.21.4"
+                "watchpack": "2.4.0"
             },
             "bin": {
                 "next": "dist/bin/next"
             },
             "engines": {
-                "node": ">=16.8.0"
+                "node": ">=16.14.0"
             },
             "optionalDependencies": {
-                "@next/swc-darwin-arm64": "13.4.19",
-                "@next/swc-darwin-x64": "13.4.19",
-                "@next/swc-linux-arm64-gnu": "13.4.19",
-                "@next/swc-linux-arm64-musl": "13.4.19",
-                "@next/swc-linux-x64-gnu": "13.4.19",
-                "@next/swc-linux-x64-musl": "13.4.19",
-                "@next/swc-win32-arm64-msvc": "13.4.19",
-                "@next/swc-win32-ia32-msvc": "13.4.19",
-                "@next/swc-win32-x64-msvc": "13.4.19"
+                "@next/swc-darwin-arm64": "13.5.4",
+                "@next/swc-darwin-x64": "13.5.4",
+                "@next/swc-linux-arm64-gnu": "13.5.4",
+                "@next/swc-linux-arm64-musl": "13.5.4",
+                "@next/swc-linux-x64-gnu": "13.5.4",
+                "@next/swc-linux-x64-musl": "13.5.4",
+                "@next/swc-win32-arm64-msvc": "13.5.4",
+                "@next/swc-win32-ia32-msvc": "13.5.4",
+                "@next/swc-win32-x64-msvc": "13.5.4"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.1.0",
@@ -1863,9 +1862,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-            "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+            "version": "8.4.31",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -1874,10 +1873,14 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/postcss"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ],
             "dependencies": {
-                "nanoid": "^3.3.4",
+                "nanoid": "^3.3.6",
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
             },
@@ -2334,33 +2337,6 @@
                 "node": ">=14.0.0"
             }
         },
-        "node_modules/tailwindcss/node_modules/postcss": {
-            "version": "8.4.30",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
-            "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "dependencies": {
-                "nanoid": "^3.3.6",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
-            }
-        },
         "node_modules/tailwindcss/node_modules/postcss-js": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
@@ -2533,14 +2509,6 @@
             "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg==",
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/zod": {
-            "version": "3.21.4",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-            "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
-            "funding": {
-                "url": "https://github.com/sponsors/colinhacks"
             }
         }
     },
@@ -2789,62 +2757,62 @@
             }
         },
         "@next/env": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.4.19.tgz",
-            "integrity": "sha512-FsAT5x0jF2kkhNkKkukhsyYOrRqtSxrEhfliniIq0bwWbuXLgyt3Gv0Ml+b91XwjwArmuP7NxCiGd++GGKdNMQ=="
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/env/-/env-13.5.4.tgz",
+            "integrity": "sha512-LGegJkMvRNw90WWphGJ3RMHMVplYcOfRWf2Be3td3sUa+1AaxmsYyANsA+znrGCBjXJNi4XAQlSoEfUxs/4kIQ=="
         },
         "@next/swc-darwin-arm64": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.4.19.tgz",
-            "integrity": "sha512-vv1qrjXeGbuF2mOkhkdxMDtv9np7W4mcBtaDnHU+yJG+bBwa6rYsYSCI/9Xm5+TuF5SbZbrWO6G1NfTh1TMjvQ==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-13.5.4.tgz",
+            "integrity": "sha512-Df8SHuXgF1p+aonBMcDPEsaahNo2TCwuie7VXED4FVyECvdXfRT9unapm54NssV9tF3OQFKBFOdlje4T43VO0w==",
             "optional": true
         },
         "@next/swc-darwin-x64": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.4.19.tgz",
-            "integrity": "sha512-jyzO6wwYhx6F+7gD8ddZfuqO4TtpJdw3wyOduR4fxTUCm3aLw7YmHGYNjS0xRSYGAkLpBkH1E0RcelyId6lNsw==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-13.5.4.tgz",
+            "integrity": "sha512-siPuUwO45PnNRMeZnSa8n/Lye5ZX93IJom9wQRB5DEOdFrw0JjOMu1GINB8jAEdwa7Vdyn1oJ2xGNaQpdQQ9Pw==",
             "optional": true
         },
         "@next/swc-linux-arm64-gnu": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.4.19.tgz",
-            "integrity": "sha512-vdlnIlaAEh6H+G6HrKZB9c2zJKnpPVKnA6LBwjwT2BTjxI7e0Hx30+FoWCgi50e+YO49p6oPOtesP9mXDRiiUg==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-13.5.4.tgz",
+            "integrity": "sha512-l/k/fvRP/zmB2jkFMfefmFkyZbDkYW0mRM/LB+tH5u9pB98WsHXC0WvDHlGCYp3CH/jlkJPL7gN8nkTQVrQ/2w==",
             "optional": true
         },
         "@next/swc-linux-arm64-musl": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.4.19.tgz",
-            "integrity": "sha512-aU0HkH2XPgxqrbNRBFb3si9Ahu/CpaR5RPmN2s9GiM9qJCiBBlZtRTiEca+DC+xRPyCThTtWYgxjWHgU7ZkyvA==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-13.5.4.tgz",
+            "integrity": "sha512-YYGb7SlLkI+XqfQa8VPErljb7k9nUnhhRrVaOdfJNCaQnHBcvbT7cx/UjDQLdleJcfyg1Hkn5YSSIeVfjgmkTg==",
             "optional": true
         },
         "@next/swc-linux-x64-gnu": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.4.19.tgz",
-            "integrity": "sha512-htwOEagMa/CXNykFFeAHHvMJeqZfNQEoQvHfsA4wgg5QqGNqD5soeCer4oGlCol6NGUxknrQO6VEustcv+Md+g==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-13.5.4.tgz",
+            "integrity": "sha512-uE61vyUSClnCH18YHjA8tE1prr/PBFlBFhxBZis4XBRJoR+txAky5d7gGNUIbQ8sZZ7LVkSVgm/5Fc7mwXmRAg==",
             "optional": true
         },
         "@next/swc-linux-x64-musl": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.4.19.tgz",
-            "integrity": "sha512-4Gj4vvtbK1JH8ApWTT214b3GwUh9EKKQjY41hH/t+u55Knxi/0wesMzwQRhppK6Ddalhu0TEttbiJ+wRcoEj5Q==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-13.5.4.tgz",
+            "integrity": "sha512-qVEKFYML/GvJSy9CfYqAdUexA6M5AklYcQCW+8JECmkQHGoPxCf04iMh7CPR7wkHyWWK+XLt4Ja7hhsPJtSnhg==",
             "optional": true
         },
         "@next/swc-win32-arm64-msvc": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.4.19.tgz",
-            "integrity": "sha512-bUfDevQK4NsIAHXs3/JNgnvEY+LRyneDN788W2NYiRIIzmILjba7LaQTfihuFawZDhRtkYCv3JDC3B4TwnmRJw==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-13.5.4.tgz",
+            "integrity": "sha512-mDSQfqxAlfpeZOLPxLymZkX0hYF3juN57W6vFHTvwKlnHfmh12Pt7hPIRLYIShk8uYRsKPtMTth/EzpwRI+u8w==",
             "optional": true
         },
         "@next/swc-win32-ia32-msvc": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.4.19.tgz",
-            "integrity": "sha512-Y5kikILFAr81LYIFaw6j/NrOtmiM4Sf3GtOc0pn50ez2GCkr+oejYuKGcwAwq3jiTKuzF6OF4iT2INPoxRycEA==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-13.5.4.tgz",
+            "integrity": "sha512-aoqAT2XIekIWoriwzOmGFAvTtVY5O7JjV21giozBTP5c6uZhpvTWRbmHXbmsjZqY4HnEZQRXWkSAppsIBweKqw==",
             "optional": true
         },
         "@next/swc-win32-x64-msvc": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.4.19.tgz",
-            "integrity": "sha512-YzA78jBDXMYiINdPdJJwGgPNT3YqBNNGhsthsDoWHL9p24tEJn9ViQf/ZqTbwSpX/RrkPupLfuuTH2sf73JBAw==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-13.5.4.tgz",
+            "integrity": "sha512-cyRvlAxwlddlqeB9xtPSfNSCRy8BOa4wtMo0IuI9P7Y0XT2qpDrpFKRyZ7kUngZis59mPVla5k8X1oOJ8RxDYg==",
             "optional": true
         },
         "@nodelib/fs.scandir": {
@@ -3008,9 +2976,9 @@
             }
         },
         "@swc/helpers": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.1.tgz",
-            "integrity": "sha512-sJ902EfIzn1Fa+qYmjdQqh8tPsoxyBz+8yBKC2HKUxyezKJFwPGOn7pv4WY6QuQW//ySQi5lJjA/ZT9sNWWNTg==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.2.tgz",
+            "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
             "requires": {
                 "tslib": "^2.4.0"
             }
@@ -3600,27 +3568,26 @@
             "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
         },
         "next": {
-            "version": "13.4.19",
-            "resolved": "https://registry.npmjs.org/next/-/next-13.4.19.tgz",
-            "integrity": "sha512-HuPSzzAbJ1T4BD8e0bs6B9C1kWQ6gv8ykZoRWs5AQoiIuqbGHHdQO7Ljuvg05Q0Z24E2ABozHe6FxDvI6HfyAw==",
+            "version": "13.5.4",
+            "resolved": "https://registry.npmjs.org/next/-/next-13.5.4.tgz",
+            "integrity": "sha512-+93un5S779gho8y9ASQhb/bTkQF17FNQOtXLKAj3lsNgltEcF0C5PMLLncDmH+8X1EnJH1kbqAERa29nRXqhjA==",
             "requires": {
-                "@next/env": "13.4.19",
-                "@next/swc-darwin-arm64": "13.4.19",
-                "@next/swc-darwin-x64": "13.4.19",
-                "@next/swc-linux-arm64-gnu": "13.4.19",
-                "@next/swc-linux-arm64-musl": "13.4.19",
-                "@next/swc-linux-x64-gnu": "13.4.19",
-                "@next/swc-linux-x64-musl": "13.4.19",
-                "@next/swc-win32-arm64-msvc": "13.4.19",
-                "@next/swc-win32-ia32-msvc": "13.4.19",
-                "@next/swc-win32-x64-msvc": "13.4.19",
-                "@swc/helpers": "0.5.1",
+                "@next/env": "13.5.4",
+                "@next/swc-darwin-arm64": "13.5.4",
+                "@next/swc-darwin-x64": "13.5.4",
+                "@next/swc-linux-arm64-gnu": "13.5.4",
+                "@next/swc-linux-arm64-musl": "13.5.4",
+                "@next/swc-linux-x64-gnu": "13.5.4",
+                "@next/swc-linux-x64-musl": "13.5.4",
+                "@next/swc-win32-arm64-msvc": "13.5.4",
+                "@next/swc-win32-ia32-msvc": "13.5.4",
+                "@next/swc-win32-x64-msvc": "13.5.4",
+                "@swc/helpers": "0.5.2",
                 "busboy": "1.6.0",
                 "caniuse-lite": "^1.0.30001406",
-                "postcss": "8.4.14",
+                "postcss": "8.4.31",
                 "styled-jsx": "5.1.1",
-                "watchpack": "2.4.0",
-                "zod": "3.21.4"
+                "watchpack": "2.4.0"
             }
         },
         "node-domexception": {
@@ -3710,11 +3677,11 @@
             "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg=="
         },
         "postcss": {
-            "version": "8.4.14",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
-            "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+            "version": "8.4.31",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
             "requires": {
-                "nanoid": "^3.3.4",
+                "nanoid": "^3.3.6",
                 "picocolors": "^1.0.0",
                 "source-map-js": "^1.0.2"
             }
@@ -3951,16 +3918,6 @@
                 "sucrase": "^3.32.0"
             },
             "dependencies": {
-                "postcss": {
-                    "version": "8.4.30",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
-                    "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
-                    "requires": {
-                        "nanoid": "^3.3.6",
-                        "picocolors": "^1.0.0",
-                        "source-map-js": "^1.0.2"
-                    }
-                },
                 "postcss-js": {
                     "version": "4.0.1",
                     "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
@@ -4079,11 +4036,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.2.tgz",
             "integrity": "sha512-N/lyzTPaJasoDmfV7YTrYCI0G/3ivm/9wdG0aHuheKowWQwGTsK0Eoiw6utmzAnI6pkJa0DUVygvp3spqqEKXg=="
-        },
-        "zod": {
-            "version": "3.21.4",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.21.4.tgz",
-            "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw=="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "fuse.js": "^6.6.2",
         "json-schema-to-ts": "^2.9.2",
         "lodash": "^4.17.21",
-        "next": "^13.4.19",
+        "next": "^13.5.4",
         "node-fetch": "^3.3.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",


### PR DESCRIPTION
Resolves a security vulnerability in zod 3.22.2.