### PR TITLE
Add Application title field

### DIFF
--- a/index/nrfconnect.json
+++ b/index/nrfconnect.json
@@ -4,6 +4,7 @@
     "apps": [
         {
             "name": "ncs-example-application",
+            "title": "nRF Connect SDK example application",
             "description": "Official reference implementation for various out-of-tree concepts, like boards, drivers and a CI setup.",
             "kind": "template",
             "tags": []

--- a/resources/output_schema.json
+++ b/resources/output_schema.json
@@ -81,6 +81,9 @@
                     "name": {
                         "type": "string"
                     },
+                    "title": {
+                        "type": "string"
+                    },
                     "description": {
                         "type": "string"
                     },

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -17,7 +17,11 @@
                 "properties": {
                     "name": {
                         "type": "string",
-                        "description": "The name of the application."
+                        "description": "The name of the application repo. Should be the repo-name in the GitHub URL: https://github.com/org/repo-name."
+                    },
+                    "title": {
+                        "type": "string",
+                        "description": "Human readable name of the repo to be shown in the UI. Defaults to the name property."
                     },
                     "description": {
                         "type": "string",

--- a/scripts/generate-index-json.ts
+++ b/scripts/generate-index-json.ts
@@ -110,6 +110,7 @@ async function fetchRepoData(
             owner: orgId,
             description: app.description ?? repoData.description ?? '',
             name: app.name,
+            title: app.title,
             defaultBranch: repoData.default_branch,
             forks: repoData.forks_count,
             isTemplate: repoData.is_template ?? false,

--- a/site/src/app/AppBlock.tsx
+++ b/site/src/app/AppBlock.tsx
@@ -30,7 +30,7 @@ function AppBlock({ app, setShowingAppId }: Props): JSX.Element {
             <div className="flex flex-col">
                 <div className="flex flex-wrap items-center justify-between">
                     <div className="flex items-center gap-2">
-                        <h1 className="text-xl text-gray-600">{app.name}</h1>
+                        <h1 className="text-xl text-gray-600">{app.title ?? app.name}</h1>
                         <a href={app.repo} target="_blank" title="Visit Website">
                             <ArrowTopRightOnSquareIcon
                                 className="hoverable-icon"

--- a/site/src/schema.ts
+++ b/site/src/schema.ts
@@ -57,7 +57,13 @@ export const appMetadataSchema = {
     properties: {
         name: {
             type: 'string',
-            description: 'The name of the application.',
+            description:
+                'The name of the application repo. Should be the repo-name in the GitHub URL: https://github.com/org/repo-name.',
+        },
+        title: {
+            type: 'string',
+            description:
+                'Human readable name of the repo to be shown in the UI. Defaults to the name property.',
         },
         description: {
             type: 'string',
@@ -133,6 +139,7 @@ export const appSchema = {
     properties: {
         id: { type: 'string' },
         name: { type: 'string' },
+        title: { type: 'string' },
         description: { type: 'string' },
         license: { type: 'string' },
         repo: { type: 'string' },


### PR DESCRIPTION
Adds an optional title field for setting the human readable title of the repo in the index. Sets the title for the NCS example application.

Demo: https://trond-snekvik.github.io/ncs-app-index/