### PR TITLE
Fix repo url

### DIFF
--- a/scripts/generate-index-json.ts
+++ b/scripts/generate-index-json.ts
@@ -68,7 +68,7 @@ async function fetchOrgData({
             isPartner: partnerIds.includes(orgId),
             type: userData.data.type as (typeof validOrgKinds)[number],
             urls: {
-                support: userData.data.url,
+                support: userData.data.html_url,
                 email: userData.data.email ?? undefined,
                 blog: userData.data.blog ?? undefined,
                 twitter: userData.data.twitter_username ?? undefined,


### PR DESCRIPTION
The repo URL should be the `html_url`, as the `url` is a link to the API
url, which is just a raw json file.
