### PR TITLE
Add golioth.json to the ncs index

### DIFF
--- a/index/golioth.json
+++ b/index/golioth.json
@@ -1,0 +1,27 @@
+{
+    "name": "golioth",
+    "description": "Golioth Cloud platform, which includes a device SDK, example code, and Reference Designs",
+    "apps": [
+        {
+            "name": "reference-design-template",
+            "title": "The Golioth Reference Design template",
+            "description": "This starter project is a standalone application that includes databases (both stateful and time-based), Over-the-air update capabilities, settings service, remote procedure calls (RPCs)",
+            "kind": "template",
+            "tags": ["dfu","lte"]
+        },
+        {
+            "name": "reference-design-can-asset-tracker",
+            "title": "CAN / OBD-II Asset Tracker Reference Design",
+            "description": "This Reference Design requires external hardware on top of an nRF9160-DK (see https://projects.golioth.io/reference-designs/can-asset-tracker/guide-nrf9160-dk/), but includes all code required to pass messages received on a CAN bus back to the Cloud, as well as regular GPS readings. Over-the-air updats are built in.",
+            "kind": "template",
+            "tags": ["dfu","lte"]
+        },
+        {
+            "name": "reference-design-air-quality",
+            "title": "Air Quality Monitor Reference Design",
+            "description": "This Reference Design requires external hardware on top of an nRF9160-DK (see https://projects.golioth.io/reference-designs/air-quality-monitor/guide-nrf9160-dk), but includes all code required to monitor readings from connected air quality sensors and pass back to the Cloud. Includes remote procedure call to clean sensor, and Over-the-air updats are built in.",
+            "kind": "template",
+            "tags": ["dfu","lte"]
+        }
+    ]
+}

--- a/index/golioth.json
+++ b/index/golioth.json
@@ -12,14 +12,14 @@
         {
             "name": "reference-design-can-asset-tracker",
             "title": "CAN / OBD-II Asset Tracker Reference Design",
-            "description": "This Reference Design requires external hardware on top of an nRF9160-DK (see https://projects.golioth.io/reference-designs/can-asset-tracker/guide-nrf9160-dk/), but includes all code required to pass messages received on a CAN bus back to the Cloud, as well as regular GPS readings. Over-the-air updats are built in.",
+            "description": "This Reference Design requires external hardware on top of an nRF9160-DK (see https://projects.golioth.io/reference-designs/can-asset-tracker/guide-nrf9160-dk/), but includes all code required to pass messages received on a CAN bus back to the Cloud, as well as regular GPS readings. Over-the-air updates are built in.",
             "kind": "template",
             "tags": ["dfu","lte"]
         },
         {
             "name": "reference-design-air-quality",
             "title": "Air Quality Monitor Reference Design",
-            "description": "This Reference Design requires external hardware on top of an nRF9160-DK (see https://projects.golioth.io/reference-designs/air-quality-monitor/guide-nrf9160-dk), but includes all code required to monitor readings from connected air quality sensors and pass back to the Cloud. Includes remote procedure call to clean sensor, and Over-the-air updats are built in.",
+            "description": "This Reference Design requires external hardware on top of an nRF9160-DK (see https://projects.golioth.io/reference-designs/air-quality-monitor/guide-nrf9160-dk), but includes all code required to monitor readings from connected air quality sensors and pass back to the Cloud. Includes remote procedure call to clean sensor, and Over-the-air updates are built in.",
             "kind": "template",
             "tags": ["dfu","lte"]
         }


### PR DESCRIPTION
This includes 3 items to add to the NCS index:

- https://github.com/golioth/reference-design-template
- https://github.com/golioth/reference-design-can-asset-tracker
- https://github.com/golioth/reference-design-air-quality

The reference designs that have hardware have an associated guide instructing people how to obtain the necessary hardware, as well as how to integrate everything together. 