### PR TITLE
Add license to app listing

### DIFF
--- a/index/golioth.json
+++ b/index/golioth.json
@@ -14,6 +14,7 @@
             "title": "CAN / OBD-II Asset Tracker Reference Design",
             "description": "This Reference Design requires external hardware on top of an nRF9160-DK (see [https://projects.golioth.io/reference-designs/can-asset-tracker/guide-nrf9160-dk/](https://projects.golioth.io/reference-designs/can-asset-tracker/guide-nrf9160-dk/), but includes all code required to pass messages received on a CAN bus back to the Cloud, as well as regular GPS readings. Over-the-air updates are built in.",
             "kind": "template",
+            "license": "Apache 2.0",
             "tags": ["dfu","lte"]
         },
         {
@@ -21,6 +22,7 @@
             "title": "Air Quality Monitor Reference Design",
             "description": "This Reference Design requires external hardware on top of an nRF9160-DK (see [https://projects.golioth.io/reference-designs/air-quality-monitor/guide-nrf9160-dk](https://projects.golioth.io/reference-designs/air-quality-monitor/guide-nrf9160-dk/), but includes all code required to monitor readings from connected air quality sensors and pass back to the Cloud. Includes remote procedure call to clean sensor, and Over-the-air updates are built in.",
             "kind": "template",
+            "license": "Apache 2.0",
             "tags": ["dfu","lte"]
         }
     ]

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -63,6 +63,10 @@
                             ]
                         },
                         "description": "An array of tags describing the application."
+                    },
+                    "license": {
+                        "type": "string",
+                        "description": "The name of the application license, e.g. \"Apache 2.0\". Inferred from the repo if missing."
                     }
                 },
                 "additionalProperties": false,

--- a/scripts/generate-index-json.ts
+++ b/scripts/generate-index-json.ts
@@ -137,7 +137,7 @@ async function fetchRepoData(
             isTemplate: repoData.is_template ?? false,
             kind: app.kind,
             lastUpdate: repoData.updated_at,
-            license: repoData.license?.spdx_id ?? undefined,
+            license: app.license ?? repoData.license?.name ?? undefined,
             watchers: repoData.watchers_count,
             releases: releases.data.map((release) => ({
                 date: release.created_at,

--- a/site/src/app/AppBlock.tsx
+++ b/site/src/app/AppBlock.tsx
@@ -12,6 +12,7 @@ import {
     CommandLineIcon,
     ArrowTopRightOnSquareIcon,
     CheckBadgeIcon,
+    ScaleIcon,
 } from '@heroicons/react/20/solid';
 
 import { NormalisedApp } from '../schema';
@@ -82,7 +83,9 @@ function AppBlock({ app, setShowingAppId }: Props): JSX.Element {
                 <TagList app={app} />
             </div>
 
-            <Markdown disallowedElements={["img"]} className="description">{app.description}</Markdown>
+            <Markdown disallowedElements={['img']} className="description">
+                {app.description}
+            </Markdown>
 
             <div className="flex flex-wrap items-center gap-2">
                 <VSCodeButton app={app} />
@@ -94,10 +97,18 @@ function AppBlock({ app, setShowingAppId }: Props): JSX.Element {
                     Instructions <CommandLineIcon width={20} height={20} />
                 </button>
             </div>
-
-            <p className="float-right text-xs font-thin italic text-gray-600">
-                Last updated {formatRelative(new Date(app.lastUpdate), new Date())}
-            </p>
+            <div className="flex justify-between gap-4 text-xs text-gray-600">
+                <span className="flex gap-1">
+                    {app.license && (
+                        <>
+                            <ScaleIcon className={smallIconClass} /> {app.license}
+                        </>
+                    )}
+                </span>
+                <span className="float-right font-thin italic">
+                    Last updated {formatRelative(new Date(app.lastUpdate), new Date())}
+                </span>
+            </div>
         </li>
     );
 }

--- a/site/src/schema.ts
+++ b/site/src/schema.ts
@@ -80,6 +80,11 @@ export const appMetadataSchema = {
             items: appTagSchema,
             description: 'An array of tags describing the application.',
         },
+        license: {
+            type: 'string',
+            description:
+                'The name of the application license, e.g. "Apache 2.0". Inferred from the repo if missing.',
+        },
     },
     additionalProperties: false,
     required: ['name', 'kind', 'tags'],


### PR DESCRIPTION
Adds a small license icon and name at the bottom left of each AppBlock.
This primarily relies on GitHub's license detection mechanism, but can
be overwritten in the application entries if GitHub fails to detect the
right one.

![image](https://github.com/nrfconnect/ncs-app-index/assets/7857838/e3cd5bb0-8998-49a1-9347-1470fd35309f)


Adds manual license names to Golioth's apps.