### PR TITLE
Run verification on pull requests

### DIFF
--- a/.github/workflows/pages-deploy.yaml
+++ b/.github/workflows/pages-deploy.yaml
@@ -4,6 +4,9 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
+  # Run build job on pull requests. Deploy is skipped
+  pull_request:
+    types: [opened, synchronize, reopened]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -79,6 +82,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
+    if: success() && github.ref == 'refs/heads/main'
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/site/src/sampleData.ts
+++ b/site/src/sampleData.ts
@@ -42,6 +42,7 @@ function createFakeApp(): AppIndex['apps'][number] {
         license: faker.word.verb(),
         tags: faker.helpers.arrayElements(validTags),
         watchers: faker.number.int({ max: 10 }),
+        stars: faker.number.int({ max: 10 }),
         manifest: faker.lorem.word(),
         owner: faker.helpers.arrayElement(companyIds),
         repo: `https://github.com/${faker.lorem.slug()}/${id}`,


### PR DESCRIPTION
Runs pages-deploy on all PRs, but skips the actual deploy job.
Fixes type error in sample data only discovered after merging #27.