### PR TITLE
Add apps field for globbing for applications 

### DIFF
--- a/index/circuitdojo.json
+++ b/index/circuitdojo.json
@@ -7,7 +7,8 @@
             "title": "nRF9160 Feather Examples and Drivers",
             "description": "Zephyr examples and drivers for the [nRF9160 Feather](https://docs.circuitdojo.com/nrf9160-getting-started.html)",
             "kind": "sample",
-            "tags": ["lte"]
+            "tags": ["lte"],
+            "apps": "samples/*"
         }
     ]
 }

--- a/index/nrfconnect.json
+++ b/index/nrfconnect.json
@@ -7,7 +7,8 @@
             "title": "nRF Connect SDK example application",
             "description": "Official reference implementation for various out-of-tree concepts, like boards, drivers and a CI setup.",
             "kind": "template",
-            "tags": []
+            "tags": [],
+            "apps": "app"
         }
     ]
 }

--- a/index/onomondo.json
+++ b/index/onomondo.json
@@ -6,7 +6,8 @@
             "name": "nrf-softsim",
             "description": "Manifest repo for integrating SoftSIM and nrf-sdk",
             "kind": "sample",
-            "tags": ["lte"]
+            "tags": ["lte"],
+            "apps": "samples/*"
         }
     ]
 }

--- a/resources/output_schema.json
+++ b/resources/output_schema.json
@@ -179,6 +179,9 @@
                     "lastUpdate": {
                         "type": "string",
                         "format": "date-time"
+                    },
+                    "apps": {
+                        "type": "string"
                     }
                 },
                 "required": [

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -67,6 +67,10 @@
                     "license": {
                         "type": "string",
                         "description": "The name of the application license, e.g. \"Apache 2.0\". Inferred from the repo if missing."
+                    },
+                    "apps": {
+                        "type": "string",
+                        "description": "Glob pattern to find directories containing applications.\n\nApplications need a *.conf file and a CMakeLists.txt file at their root. The glob expressions are used to match directories, so no file pattern is necessary.\n\nBy default, the VS Code extension will assume that there's just a single application sitting at the root of the repo."
                     }
                 },
                 "additionalProperties": false,

--- a/scripts/generate-index-json.ts
+++ b/scripts/generate-index-json.ts
@@ -139,6 +139,7 @@ async function fetchRepoData(
             watchers: repoData.watchers_count,
             stars: repoData.stargazers_count,
             forks: repoData.forks_count,
+            apps: app.apps,
             releases: releases.data.map((release) => ({
                 date: release.created_at,
                 name: release.name ?? release.tag_name,

--- a/site/src/schema.ts
+++ b/site/src/schema.ts
@@ -85,6 +85,14 @@ export const appMetadataSchema = {
             description:
                 'The name of the application license, e.g. "Apache 2.0". Inferred from the repo if missing.',
         },
+        apps: {
+            type: 'string',
+            description: [
+                'Glob pattern to find directories containing applications.',
+                'Applications need a *.conf file and a CMakeLists.txt file at their root. The glob expressions are used to match directories, so no file pattern is necessary.',
+                "By default, the VS Code extension will assume that there's just a single application sitting at the root of the repo.",
+            ].join('\n\n'),
+        },
     },
     additionalProperties: false,
     required: ['name', 'kind', 'tags'],
@@ -173,6 +181,7 @@ export const appSchema = {
         forks: { type: 'integer' },
         defaultBranch: { type: 'string' },
         lastUpdate: { type: 'string', format: 'date-time' },
+        apps: { type: 'string' },
     },
     required: [
         'id',


### PR DESCRIPTION
This field will be used by VS Code to add `application` entries in the
workspace settings when cloning the repo, allowing users to see all
available applications for the start.