### PR TITLE
app: add query params to filter the apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,12 @@ To verify that your application index is correctly picked up by the [nRF Connect
 1. In the extension's **Welcome View**, select [**Create a new application** > **Browse application index**](https://nrfconnect.github.io/vscode-nrf-connect/reference/ui_sidebar_welcome.html#create-a-new-application).
 
 Your custom `nrf-connect.appIndexUri` will be used to list the applications in the index.
+
+## Query parameters
+
+The Index exposes a number of query parameters that allows to efficiently filter the applications.
+
+| Parameter | Type | Description | Example |
+|-----------|------|-------------|---------|
+| app  | string | Show applications that include the **app** in their name, title, description, or tags | ?app=air+quality |
+

--- a/site/src/app/Root.tsx
+++ b/site/src/app/Root.tsx
@@ -49,6 +49,15 @@ function Root(props: Props) {
         return () => dialogRef.current?.removeEventListener('close', onDialogClose);
     });
 
+    useEffect(() => {
+        const searchParams = new URLSearchParams(window.location.search);
+        const appFilter = searchParams.get("app");
+
+        if (appFilter) {
+            dispatchFilters({ type: 'textSearch', payload: appFilter });
+        }
+    }, []);
+
     const showingApp = useMemo(
         () => props.apps.find((app) => app.id === showingAppId),
         [showingAppId],


### PR DESCRIPTION
A part of VSC-2486
Filter the applications by feeding the filter with the query parameters.