### PR TITLE
doc: rename extensions + misc edits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contribution guidelines
 
-If you or your organization has a project that you'd like to include in the nRF Connect SDK App Index, you can do so by opening a pull request against this repository.
+If you or your organization has a project that you'd like to include in the nRF Connect SDK Add-on index, you can do so by opening a pull request against this repository.
 
 The pull request must include a JSON file named after your GitHub account in the `index` directory (for example, `index/nrfconnect.json`).
 
@@ -13,4 +13,4 @@ If you use Visual Studio Code, the editor will automatically provide validation 
 
 ## Publishing
 
-Once your pull request is approved and merged, the application index will be rebuilt and republished automatically.
+Once your pull request is approved and merged, the add-on index will be rebuilt and published automatically.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
-# nRF Connect SDK App Index
+# nRF Connect SDK Add-on index
 
-An index of applications built for the nRF Connect SDK.
-
+This repository includes a collection of index pages for publicly available nRF Connect SDK Add-ons, which are supplementary modules that extend the functionality of the [nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html). You can access the index from the [nRF Connect for VS Code extension](https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/index.html).
 ----
 
 ## Contributing
 
-If you or your organization has a project that you'd like to include in the nRF Connect SDK App Index, you can open a pull request against this repository. Read the [`CONTRIBUTING`](./CONTRIBUTING.md) file for more information.
+If you or your organization has a project that you'd like to include in this repository, open a pull request against it. Read the [`CONTRIBUTING`](./CONTRIBUTING.md) file for more information.
 
 ----
 
 ## Development
 
-To develop an application index of your own, you need to generate a new, custom `index.json` file and [contribute](./CONTRIBUTING.md) it to this repository (using a different name). Use the information in the following sections to make sure that the file is set up correctly.
+To create an add-on index page of your own, you need to generate a new, custom `index.json` file and [contribute it](./CONTRIBUTING.md) to this repository (using a different name). Use the information in the following sections to make sure that the JSON file is set up correctly.
 
 ### Generating index.json
 
@@ -29,7 +28,7 @@ To generate an `index.json` template file:
    ```
    npm run generate-index-json
    ```
-   The `index.json` is created in the `resources` directory.
+   The `index.json` file is created in the `resources` directory.
 
 1. Copy `index.json` to `./site/public/`.
 
@@ -39,19 +38,19 @@ To create an `index.json` of your own, you can either [generate a template](#gen
 Your custom JSON file must include the following information:
 
 * Information about your account or organization (`name` and `description`).
-* Inside the `apps` array, an entry for each app you want to be shown in the index:
+* Inside the `apps` array, an entry for each add-on you want to be shown in the index:
 
-  * `name` must match the application's GitHub repository in your account.
+  * `name` must match the add-on's GitHub repository in your account.
   * `title` is the human-readable name of the repository.
-  * `description` is the short description of the application.
+  * `description` is the short description of the add-on.
   * `manifest` is the alternative name of the west manifest. Defaults to `west.yml`.
-  * `kind` is the type of application
-  * `tags` are the tags that will be used to categorize the application.
+  * `kind` is the type of add-on.
+  * `tags` are the tags that will be used to categorize the add-on.
   * `license` is the license type name.
-  * `apps` is the global pattern to find directories containing applications.
-  * `compatibleNcs` are the NCS' versions the application is compatible with.
+  * `apps` is the global pattern to find directories containing add-ons.
+  * `compatibleNcs` are the nRF Connect SDK's versions the add-on is compatible with.
 
-Most of the information provided in these entries will be displayed on the application index page.
+Most of the information provided in these entries will be displayed on the add-on index page.
 For more information about each entry, see `appMetadataSchema` in the `resources/schema.json` file.
 
 #### Schemas
@@ -77,7 +76,7 @@ Once you have your `index.json` file, you can set up a local server to test it:
 
 ### Verifying website locally
 
-This repository includes a static website that displays the contributed applications in a searchable frontend. It's developed using the [Next.js](https://nextjs.org/) React framework, and uses [Tailwind](https://tailwindcss.com/) for styling.
+This repository includes a static website that displays the contributed add-ons in a searchable frontend. It's developed using the [Next.js](https://nextjs.org/) React framework, and uses [Tailwind](https://tailwindcss.com/) for styling.
 
 To verify your application index website locally:
 
@@ -96,11 +95,11 @@ You can customize the local website in the following ways:
 
 * By default, the site runs on port 3000, but this can be overridden by setting the `PORT` environment variable.
 
-* Application data is read at build time. For development purposes, sample data can be imported from `sampleData.ts`.
+* Add-on data is read at build time. For development purposes, sample data can be imported from `sampleData.ts`.
 
 ### Verifying index in the extension
 
-To verify that your application index is correctly picked up by the [nRF Connect for Visual Studio Code extension], set the extension to fetch the application index from the custom URL:
+To verify that your add-on index is correctly picked up by the [nRF Connect for Visual Studio Code extension], set the extension to fetch the add-on index from the custom URL:
 
 1. In Visual Studio Code, open the `settings.json` workspace settings file.
 
@@ -113,13 +112,13 @@ To verify that your application index is correctly picked up by the [nRF Connect
 
 1. In the extension's **Welcome View**, select [**Create a new application** > **Browse application index**](https://nrfconnect.github.io/vscode-nrf-connect/reference/ui_sidebar_welcome.html#create-a-new-application).
 
-Your custom `nrf-connect.appIndexUri` will be used to list the applications in the index.
+Your custom `nrf-connect.appIndexUri` will be used to list the add-ons in the index.
 
 ## Query parameters
 
-The Index exposes a number of query parameters that allows to efficiently filter the applications.
+The add-on index exposes several query parameters for filtering its contents.
 
-| Parameter | Type | Description | Example |
-|-----------|------|-------------|---------|
-| app  | string | Show applications that include the **app** in their name, title, description, or tags | ?app=air+quality |
-| ncs  | string | Show applications that are compatible with **ncs** version | ?ncs=v2.5.0 |
+| Parameter |  Type  |                                    Description                                    |      Example       |
+| --------- | ------ | --------------------------------------------------------------------------------- | ------------------ |
+| app       | string | Show add-ons that include the **app** in their name, title, description, or tags. | `?app=air+quality` |
+| ncs       | string | Show add-ons that are compatible with a given nRF Connect SDK version.            | `?ncs=v2.5.0`      |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nRF Connect SDK Add-on index
 
-This repository includes a collection of index pages for publicly available nRF Connect SDK Add-ons, which are supplementary modules that extend the functionality of the [nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html). You can access the index from the [nRF Connect for VS Code extension](https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/index.html).
+This repository includes a collection of index pages for publicly available nRF Connect SDK Add-ons, which are supplementary modules that extend the functionality of the [nRF Connect SDK](https://docs.nordicsemi.com/bundle/ncs-latest/page/nrf/index.html). You can access the index from the [nRF Connect for VS Code extension](https://docs.nordicsemi.com/bundle/nrf-connect-vscode/page/index.html), and browse it on [its webpage](https://nrfconnect.github.io/ncs-app-index/).
 ----
 
 ## Contributing


### PR DESCRIPTION
Renamed nRF Connect SDK Extensions and App Index to use add-ons. Edited several minor style and semantic issues.