### PR TITLE
Add Blecon Device SDK to index

### DIFF
--- a/index/blecon.json
+++ b/index/blecon.json
@@ -1,0 +1,28 @@
+{
+    "name": "Blecon",
+    "description": "Blecon IoT Connectivity for Bluetooth SDK",
+    "apps": [
+        {
+            "name": "blecon-device-sdk",
+            "title": "Blecon Device SDK",
+            "description": "Enable Blecon Bluetooth to Cloud IoT Connectivity on your device using the Blecon Device SDK. This SDK includes the Blecon modem libraries and samples.",
+            "kind": "sample",
+            "license": "Apache License 2.0",
+            "apps": "examples/zephyr/*",
+            "releases": [
+                {
+                    "date": "2024-08-09T14:46:00Z",
+                    "name": "Blecon Device SDK v1.2.1",
+                    "tag": "v1.2.1",
+                    "sdk": "v2.7.0"
+                }
+            ],
+            "tags": [
+                "blecon",
+                "bluetooth",
+                "ble",
+                "connectivity"
+            ]
+        }
+    ]
+}

--- a/scripts/generate-index-json.ts
+++ b/scripts/generate-index-json.ts
@@ -23,7 +23,7 @@ import { ParsedOrgFile, readOrgIndexFiles } from './orgFiles';
 import { execSync } from 'child_process';
 
 const nordicOrgs: string[] = ['nrfconnect', 'nordic', 'nordicplayground'];
-const partnerOrgs: string[] = ['golioth'];
+const partnerOrgs: string[] = ['golioth', 'blecon'];
 
 function notUndefined<T>(value: T | undefined): value is T {
     return value !== undefined;


### PR DESCRIPTION
This PR adds `blecon.json` to the index, which includes the Blecon Device SDK v1.2.1 release.
We are also a Nordic partner now so the PR adds us to the list of partner organizations.

Please let me know if/how I can tweak this PR. Thanks!