### PR TITLE
Add Zigbee to nRF Connect SDK index

### DIFF
--- a/index/nrfconnect.json
+++ b/index/nrfconnect.json
@@ -3,6 +3,24 @@
     "description": "Official nRF Connect SDK applications",
     "apps": [
         {
+            "name": "ncs-zigbee",
+            "title": "Zigbee",
+            "description": "The Zigbee add-on for the nRF Connect SDK provides support for developing Zigbee applications based on the third-party precompiled ZBOSS stack.",
+            "kind": "template",
+            "tags": ["zigbee", "connectivity"],
+            "apps": "samples/*",
+            "license": "Other",
+            "releases": [
+              {
+                "name": "Zigbee add-on v0.1.0",
+                "tag": "v0.1.0",
+                "date": "2024-11-15T12:47:22Z",
+                "sdk": "v2.8.0"
+              }
+            ],
+            "defaultBranch": "v0.1.0"
+        },
+        {
             "name": "ncs-example-application",
             "title": "nRF Connect SDK example application",
             "description": "Official reference implementation for various out-of-tree concepts, like boards, drivers and a CI setup.",

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -102,6 +102,10 @@
                         },
                         "minItems": 1
                     },
+                    "defaultBranch": {
+                        "type": "string",
+                        "description": "The default git branch that the repository is checked out. Inferred from the repo if missing."
+                    },
                     "apps": {
                         "type": "string",
                         "description": "Glob pattern to find directories containing applications.\n\nApplications need a *.conf file and a CMakeLists.txt file at their root. The glob expressions are used to match directories, so no file pattern is necessary.\n\nBy default, the VS Code extension will assume that there's just a single application sitting at the root of the repo."

--- a/scripts/generate-index-json.ts
+++ b/scripts/generate-index-json.ts
@@ -133,7 +133,7 @@ async function fetchRepoData(
             description: app.description ?? repoData.description ?? '',
             name: app.name,
             title: app.title,
-            defaultBranch: repoData.default_branch,
+            defaultBranch: app.defaultBranch ?? repoData.default_branch,
             isTemplate: repoData.is_template ?? false,
             kind: app.kind,
             lastUpdate: repoData.updated_at,

--- a/site/src/schema.ts
+++ b/site/src/schema.ts
@@ -115,7 +115,11 @@ export const appMetadataSchema = {
                 additionalProperties: false,
             },
             minItems: 1,
-        }
+        },
+        defaultBranch: {
+            type: 'string',
+            description: 'The default git branch that the repository is checked out. Inferred from the repo if missing.'
+        },
     },
     additionalProperties: false,
     required: ['name', 'kind', 'tags', 'releases'],


### PR DESCRIPTION
Add the nrfconnect/ncs-zigbee to nRF Connect SDK Addons. A tile on the webpage will look like that:
![image](https://github.com/user-attachments/assets/459ac66a-b26b-4987-8fec-7af4e41ae598)

Tile in vs code:
![image](https://github.com/user-attachments/assets/376d3323-70fd-4a3b-a769-b53f041a0766)

And the zigbee samples will be listed in the following way in the VS Code once the Add-on is downloaded:
![image](https://github.com/user-attachments/assets/9ddfe1eb-fd32-494e-8ff0-e953581e9af4)
