### PR TITLE
Add two new Golioth reference designs to the SDK add-on index

### DIFF
--- a/index/golioth.json
+++ b/index/golioth.json
@@ -11,25 +11,25 @@
             "releases": [
                 {
                     "date": "2024-02-21T21:05:15Z",
-                    "name": "Release template_v2.0.0",
+                    "name": "Reference Design Template v2.0.0",
                     "tag": "template_v2.0.0",
                     "sdk": "v2.5.1"
                 },
                 {
                     "date": "2023-11-08T19:48:02Z",
-                    "name": "Release template_v1.2.0",
+                    "name": "Reference Design Template v1.2.0",
                     "tag": "template_v1.2.0",
                     "sdk": "v2.5.0"
                 },
                 {
                     "date": "2023-08-18T19:37:19Z",
-                    "name": "Release 1.1.0",
+                    "name": "Reference Design Template v1.1.0",
                     "tag": "template_v1.1.0",
                     "sdk": "v2.4.1"
                 },
                 {
                     "date": "2023-07-14T20:37:49Z",
-                    "name": "template_v1.0.1",
+                    "name": "Reference Design Template v1.0.1",
                     "tag": "template_v1.0.1",
                     "sdk": "v2.3.0"
                 }
@@ -65,6 +65,38 @@
                   "tag": "v1.2.0",
                   "sdk": "v2.4.1"
                 }
+            ]
+        },
+        {
+            "name": "reference-design-coldchain",
+            "title": "Cold Chain Asset Tracker Reference Design",
+            "description": "This Reference Design requires external hardware on top of an nRF9160-DK (see [https://projects.golioth.io/reference-designs/cold-chain-tracker/](https://projects.golioth.io/reference-designs/cold-chain-tracker/), but includes all code required to monitor weather sensor (temperature) readings and pass back to the Cloud, as well as regular GPS readings. Configurable online/offline updates rates using settings subsystem. Over-the-air updates are built in.",
+            "kind": "template",
+            "license": "Apache 2.0",
+            "tags": ["dfu","lte"],
+            "releases": [
+                {
+                    "date": "2024-02-21T21:05:15Z",
+                    "name": "Cold Chain Monitor RD v2.0.0",
+                    "tag": "template_v2.0.0",
+                    "sdk": "v2.5.1"
+                }   
+            ]
+        },
+        {
+            "name": "reference-design-modbus-vibration-monitor",
+            "title": "Modbus Vibration Monitor Reference Design",
+            "description": "This Reference Design requires external hardware on top of an nRF9160-DK (see [https://projects.golioth.io/reference-designs/modbus-vibration-monitor/guide-nrf9160-dk](https://projects.golioth.io/reference-designs/modbus-vibration-monitor/guide-nrf9160-dk), but includes all code required to communicate over RS-485 to a Modbus server (sensor) and pass back to the Cloud. Over-the-air updates are built in.",
+            "kind": "template",
+            "license": "Apache 2.0",
+            "tags": ["dfu","lte"],
+            "releases": [
+                {
+                    "date": "2024-02-21T21:05:15Z",
+                    "name": "Modbus Vibration Monitor RD v2.0.0",
+                    "tag": "template_v2.0.0",
+                    "sdk": "v2.5.1"
+                }   
             ]
         }
     ]


### PR DESCRIPTION
Golioth is submitting new designs to the repository:

- Cold Chain Asset Tracker
- Modbus Vibration Monitor

These are two Golioth Reference designs that are locked to NCS versions that are being added to the ncs app index repo.

I also updated the names for each entry to make sure it matches the project name.

This supplants the previous pull request #44 