### PR TITLE
Extend index with `restricted` field and show padlock on the website

### DIFF
--- a/resources/output_schema.json
+++ b/resources/output_schema.json
@@ -196,6 +196,10 @@
                     },
                     "docsUrl": {
                         "type": "string"
+                    },
+                    "restricted": {
+                        "type": "boolean",
+                        "default": false
                     }
                 },
                 "required": [

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -120,6 +120,11 @@
                     "docsUrl": {
                         "type": "string",
                         "description": "The url of the addon's documentation"
+                    },
+                    "restricted": {
+                        "type": "boolean",
+                        "description": "Mark the restricted access to any of dependencies.",
+                        "default": false
                     }
                 },
                 "additionalProperties": false,

--- a/scripts/generate-index-json.ts
+++ b/scripts/generate-index-json.ts
@@ -19,6 +19,7 @@ import type {
     Organization,
     Application,
 } from '../site/src/schema';
+import { appIndexSchema } from '../site/src/schema';
 import { ParsedOrgFile, readOrgIndexFiles } from './orgFiles';
 import { execSync } from 'child_process';
 
@@ -143,6 +144,8 @@ async function fetchRepoData(
 
         let docsUrl = app.docsUrl ?? await getReadmeUrl(orgId, app);
 
+        const restricted = app.restricted ? app.restricted : appIndexSchema.properties.apps.items.properties.restricted?.default;
+
         console.log(colours.green(`Fetched data for ${orgId}/${app.name}`));
 
         return {
@@ -164,6 +167,7 @@ async function fetchRepoData(
             releases: app.releases,
             tags: app.tags,
             docsUrl: docsUrl,
+            restricted: restricted,
         };
     } catch {
         throw new Error(`Failed to fetch data for ${orgId}/${app.name}`);

--- a/site/src/app/AppBlock.tsx
+++ b/site/src/app/AppBlock.tsx
@@ -18,6 +18,7 @@ import {
     TerminalIcon,
     VerifiedIcon,
     BookIcon,
+    LockIcon,
 } from '@primer/octicons-react';
 
 import { useState } from 'react';
@@ -59,6 +60,11 @@ function AppBlock({ app, setShowingAppDetails }: Props): JSX.Element {
                             <a href={app.repo} target="_blank" title="Visit Website">
                                 <LinkExternalIcon className="hoverable-icon" size={20} />
                             </a>
+                            {app.restricted && 
+                                <div title="This addon requires additional permissions.">
+                                    <LockIcon className="hoverable-icon" size={20}/>
+                                </div>
+                            }
                         </div>
 
                         <div className="hidden items-center gap-2 md:flex">

--- a/site/src/schema.ts
+++ b/site/src/schema.ts
@@ -123,6 +123,11 @@ export const appMetadataSchema = {
         docsUrl: {
             type: 'string',
             description: `The url of the addon's documentation`
+        },
+        restricted: {
+            type: 'boolean',
+            description: 'Mark the restricted access to any of dependencies.',
+            default: false
         }
     },
     additionalProperties: false,
@@ -215,6 +220,7 @@ export const appSchema = {
         lastUpdate: { type: 'string', format: 'date-time' },
         apps: { type: 'string' },
         docsUrl: { type: 'string' },
+        restricted: { type: 'boolean', default: false },
     },
     required: [
         'id',


### PR DESCRIPTION
Contributors can add mark an addon as restricted if additional permissions are required in order to use it - for example access to some Github organization etc.
If the addon is marked as `restricted` the lock icon is shown on its tile on the website and a note is displayed when the icon is hovered:
![Screenshot from 2025-01-17 16-00-32](https://github.com/user-attachments/assets/3b5dd49c-abce-4ed4-8805-b6438de8efd1)
