### PR TITLE
Change restricted field to link to getting access docs

### DIFF
--- a/resources/output_schema.json
+++ b/resources/output_schema.json
@@ -198,8 +198,17 @@
                         "type": "string"
                     },
                     "restricted": {
-                        "type": "boolean",
-                        "default": false
+                        "type": "object",
+                        "description": "Mark the restricted access to any of the dependencies.",
+                        "properties": {
+                            "detailsUrl": {
+                                "type": "string",
+                                "description": "The URL of the documentation that explains how to grant access."
+                            }
+                        },
+                        "required": [
+                            "detailsUrl"
+                        ]
                     }
                 },
                 "required": [

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -122,9 +122,17 @@
                         "description": "The URL of the add-on's documentation"
                     },
                     "restricted": {
-                        "type": "boolean",
+                        "type": "object",
+                        "properties": {
+                            "detailsUrl": {
+                                "type": "string",
+                                "description": "The URL of the documentation that explains how to grant access."
+                            }
+                        },
                         "description": "Mark the restricted access to any of the dependencies.",
-                        "default": false
+                        "required": [
+                            "detailsUrl"
+                        ]
                     }
                 },
                 "additionalProperties": false,

--- a/scripts/generate-index-json.ts
+++ b/scripts/generate-index-json.ts
@@ -144,8 +144,6 @@ async function fetchRepoData(
 
         let docsUrl = app.docsUrl ?? await getReadmeUrl(orgId, app);
 
-        const restricted = app.restricted ? app.restricted : appIndexSchema.properties.apps.items.properties.restricted?.default;
-
         console.log(colours.green(`Fetched data for ${orgId}/${app.name}`));
 
         return {
@@ -167,7 +165,7 @@ async function fetchRepoData(
             releases: app.releases,
             tags: app.tags,
             docsUrl: docsUrl,
-            restricted: restricted,
+            restricted: app.restricted,
         };
     } catch {
         throw new Error(`Failed to fetch data for ${orgId}/${app.name}`);

--- a/site/src/app/AppBlock.tsx
+++ b/site/src/app/AppBlock.tsx
@@ -60,10 +60,13 @@ function AppBlock({ app, setShowingAppDetails }: Props): JSX.Element {
                             <a href={app.repo} target="_blank" title="Visit Website">
                                 <LinkExternalIcon className="hoverable-icon" size={20} />
                             </a>
-                            {app.restricted && 
-                                <div title="This add-on requires additional permissions.">
-                                    <LockIcon className="hoverable-icon" size={20}/>
-                                </div>
+                            {app.restricted &&
+                                <a href={app.restricted.detailsUrl}
+                                   target="_blank"
+                                   rel={'noopener noreferrer'} 
+                                   title="This add-on requires additional permissions.">
+                                   <LockIcon className="hoverable-icon" size={20}/>
+                                </a>
                             }
                         </div>
 

--- a/site/src/schema.ts
+++ b/site/src/schema.ts
@@ -125,9 +125,15 @@ export const appMetadataSchema = {
             description: `The URL of the add-on's documentation`
         },
         restricted: {
-            type: 'boolean',
+            type: 'object',
+            properties: {
+                detailsUrl: {
+                    type: 'string',
+                    description: 'The URL of the documentation that explains how to grant access.',
+                },
+            },
             description: 'Mark the restricted access to any of the dependencies.',
-            default: false
+            required: ['detailsUrl'],
         }
     },
     additionalProperties: false,
@@ -220,7 +226,17 @@ export const appSchema = {
         lastUpdate: { type: 'string', format: 'date-time' },
         apps: { type: 'string' },
         docsUrl: { type: 'string' },
-        restricted: { type: 'boolean', default: false },
+        restricted: {
+            type: 'object',
+            description: 'Mark the restricted access to any of the dependencies.',
+            properties: {
+                detailsUrl: {
+                    type: 'string',
+                    description: 'The URL of the documentation that explains how to grant access.',
+                },
+            },
+            required: ['detailsUrl'],
+        }
     },
     required: [
         'id',


### PR DESCRIPTION
The restricted field in the index file - if filled - should contain a URL pointing to a documentation explaining how to get the access. Pushing the lock button on the Index Page opens that URL in the browser.