### PR TITLE
Add status badges

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,9 @@ When submitting your index file make sure it follows the current [`JSON schema`]
 
 It is also recommended to fill the `contact` field with support information for your organization. This will be displayed when users click the **Support** button in the Add-on's tile.
 
+It is also possible to display a workflow status badge of an add-on. It works in a similar manner as a badges displayed on the README pages on Github. Use the `testStatus` field to provide
+the badge's URL for your add-on. Learn more about generating the [badges urls](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name).
+
 ## Validation
 
 If you use Visual Studio Code, the editor will automatically provide validation and autocompletion for the index file. If you are using another editor, you can use the JSON schema located at `resources/schema.json` to validate your file. Make sure that your file correctly follows the schema before creating your pull request, otherwise the CI pipeline will fail. Use the `validate-index` script  to make sure that the schema validates successfully:

--- a/index/nrfconnect.json
+++ b/index/nrfconnect.json
@@ -103,6 +103,9 @@
       "apps": "app",
       "avatar": "https://avatars.githubusercontent.com/u/40860733?s=200&v=4",
       "docsUrl": "https://github.com/nrfconnect/ncs-example-application/blob/main/README.md",
+      "testStatus": {
+        "badge": "https://github.com/nrfconnect/ncs-example-application/actions/workflows/build-using-docker.yml/badge.svg"
+      },
       "releases": [
         {
           "date": "2024-12-17T16:52:00Z",

--- a/resources/output_schema.json
+++ b/resources/output_schema.json
@@ -189,6 +189,15 @@
                     "avatar": {
                         "type": "string",
                         "description": "An image displayed next to an Add-on"
+                    },
+                    "testStatus": {
+                        "type": "object",
+                        "properties": {
+                            "badge": {
+                                "type": "string",
+                                "description": "An url pointing to a workflow status badge. How to get the badge for a repo hosted on Github: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name"
+                            }
+                        }
                     }
                 },
                 "required": [

--- a/resources/schema.json
+++ b/resources/schema.json
@@ -161,6 +161,15 @@
                         "required": [
                             "detailsUrl"
                         ]
+                    },
+                    "testStatus": {
+                        "type": "object",
+                        "properties": {
+                            "badge": {
+                                "type": "string",
+                                "description": "An url pointing to a workflow status badge. How to get the badge for a repo hosted on Github: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name"
+                            }
+                        }
                     }
                 },
                 "additionalProperties": false,

--- a/scripts/generate-index-json.ts
+++ b/scripts/generate-index-json.ts
@@ -113,6 +113,7 @@ async function fetchRepoData(
             docsUrl: app.docsUrl,
             restricted: app.restricted,
             avatar: app.avatar,
+            testStatus: app.testStatus,
         } as Application;
     } catch {
         throw new Error(`Failed to fetch data for ${orgId}/${app.name}`);

--- a/site/src/app/AppBlock.tsx
+++ b/site/src/app/AppBlock.tsx
@@ -179,11 +179,6 @@ function AppBlock({ app, setShowingAppDetails }: Props): JSX.Element {
                         <LawIcon /> {app.license}
                     </div>
                 )}
-                {/* {app.testStatus &&
-                    <div className="flex">
-                        <img src={`${app.testStatus.badge}`} className="" />
-                    </div>
-                } */}
             </div>
         </li>
     );

--- a/site/src/app/AppBlock.tsx
+++ b/site/src/app/AppBlock.tsx
@@ -93,6 +93,12 @@ function AppBlock({ app, setShowingAppDetails }: Props): JSX.Element {
                                 })}
                             />
                         )}
+
+                        {app.testStatus &&
+                            <div className="mx-2">
+                                <img src={`${app.testStatus.badge}`} className="" />
+                            </div>
+                        }
                     </div>
                 </div>
             </div>
@@ -167,12 +173,17 @@ function AppBlock({ app, setShowingAppDetails }: Props): JSX.Element {
                 </button>
             </div>
 
-            <div className="flex w-full justify-between gap-3 text-xs text-gray-600">
+            <div className="flex w-full px-1 gap-5 text-xs text-gray-600">
                 {app.license && (
                     <div className="flex items-center gap-1">
                         <LawIcon /> {app.license}
                     </div>
                 )}
+                {/* {app.testStatus &&
+                    <div className="flex">
+                        <img src={`${app.testStatus.badge}`} className="" />
+                    </div>
+                } */}
             </div>
         </li>
     );

--- a/site/src/schema.ts
+++ b/site/src/schema.ts
@@ -142,6 +142,15 @@ export const appMetadataSchema = {
             },
             description: 'Mark the restricted access to any of the dependencies.',
             required: ['detailsUrl'],
+        },
+        testStatus: {
+            type: 'object',
+            properties: {
+                badge: {
+                    type: 'string',
+                    description: 'An url pointing to a workflow status badge. How to get the badge for a repo hosted on Github: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name',
+                }
+            }
         }
     },
     additionalProperties: false,
@@ -265,7 +274,16 @@ export const appSchema = {
         avatar: { 
             type: 'string',
             description: 'An image displayed next to an Add-on',
-        }
+        },
+        testStatus: {
+            type: 'object',
+            properties: {
+                badge: {
+                    type: 'string',
+                    description: 'An url pointing to a workflow status badge. How to get the badge for a repo hosted on Github: https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name',
+                }
+            }
+        },
     },
     required: [
         'id',


### PR DESCRIPTION
Add support for displaying status badges for individual add-ons.

![image](https://github.com/user-attachments/assets/8d85c05a-af13-4289-91c0-dfe394bd02a4)

This enables to provide a link pointing to badge of a specific workflow/pipeline -> they work similarly for both github and gitlab:
- https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge#using-the-workflow-file-name
- https://docs.gitlab.com/user/project/badges/#pipeline-status-badges

The public APIs do not provide a way to get the status of a pipeline in a more reasonable format which could be used to unify the badges design. I am not using any github specific APIs endpoints that requires authentication as add-ons have been made independent from Github.