### PR TITLE
index: Add ANT Wireless SDK v2.1.0

### DIFF
--- a/index/ant.json
+++ b/index/ant.json
@@ -14,13 +14,19 @@
             ],
             "releases": [
                 {
+                    "date": "2026-04-16T00:00:00Z",
+                    "name": "v2.1.0",
+                    "tag": "v2.1.0",
+                    "sdk": "v3.2.4"
+                },
+                {
                     "date": "2025-07-24T22:31:23Z",
                     "name": "v2.0.0",
                     "tag": "v2.0.0",
                     "sdk": "v2.9.2"
                 }
             ],
-            "docsUrl": "https://www.thisisant.com/APIassets/ANTnRFConnectDoc/",
+            "docsUrl": "https://ant-nrfconnect.github.io/",
             "restricted": {
                 "detailsUrl": "https://www.thisisant.com/developer/ant/nrf-connect-sdk/"
             }


### PR DESCRIPTION
Update to latest ANT for nRF Connect SDK.
(sdk-ant v2.1.0, sdk-nrf v3.2.4)
Documentation has moved to new URL.